### PR TITLE
:sparkles: feat: Adiciona configuração de rede no Docker Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,5 @@ docker-compose.override.yml
 # Arquivos temporários relacionados ao git
 .git/
 
-# Excluir o arquivo gerar_log.py do versionamento
+# Excluir o arquivo gerar_log.py do versionamento do git
 gerar_log.py


### PR DESCRIPTION
O que foi feito:

- Adicionada a configuração de rede chamada `backend` no arquivo `docker-compose.yml`.
- Isso permite que o serviço `web` e o serviço `db` comuniquem-se de forma segura e eficiente dentro da mesma rede Docker, utilizando o driver de rede `bridge`.

Como testar:

1. Execute `docker-compose up --build` para reconstruir e inicializar o ambiente com a nova configuração de rede.
2. O serviço web estará acessível em `http://localhost:8000` e se comunicará com o banco de dados via a rede `backend`.